### PR TITLE
Use Bcrypt.Verify to detect same user key

### DIFF
--- a/Tests/CreateUserTest.cs
+++ b/Tests/CreateUserTest.cs
@@ -15,6 +15,29 @@ namespace NoCO2.Test
     }
 
     [Fact]
+    public void CorrectHashUserKey()
+    {
+      string userKey = "RandomRandomRandomRandomRandom";
+      string hashedUserKey = BCrypt.Net.BCrypt.HashPassword(userKey);
+
+      bool isMatched = BCrypt.Net.BCrypt.Verify(userKey, hashedUserKey);
+
+      Assert.True(isMatched);
+    }
+
+    [Fact]
+    public void IncorrectHashUserKey()
+    {
+      string userKey1 = "RandomRandomRandomRandomRandom";
+      string userKey2 = "IncorrectIncorrectIncorrectIncorrect";
+      string hashedUserKey = BCrypt.Net.BCrypt.HashPassword(userKey1);
+
+      bool isMatched = BCrypt.Net.BCrypt.Verify(userKey2, hashedUserKey);
+
+      Assert.False(isMatched);
+    }
+
+    [Fact]
     public async Task EmptyBody()
     {
       var user = new {};


### PR DESCRIPTION
Original user key detection does not work because the hashed key could be different every time the same userKey apply to the Bcrypt.HashPassword function. The only way to verify if the userKey correlates to hashedUserKey from database is the use Bcrypt.Verify function.

The Bcrypt.Verify function takes the unhashed string and the hashed string (with salt) as parameter. Then, take the salt from hashed string and apply hashing to unhased string with the salt taken from hashed string. 

If the final hash equals the hashed string, we have a match and the user is already created in the database. If none of the hashed userKey from database matched the after-hashed userKey, continue to insert the after-hashed userkey to the database.