### PR TITLE
Add try catch to firebaseInitializer

### DIFF
--- a/FirebaseInitializer.cs
+++ b/FirebaseInitializer.cs
@@ -8,14 +8,19 @@ public static class FirebaseInitializer
     {
         if (!isInitialized)
         {
-            string credentialsPath = "../../../Properties/noco2-e46fa-firebase-adminsdk-fta0k-c6f39e61a6.json";
+            try {
+                string credentialsPath = "../../../Properties/noco2-e46fa-firebase-adminsdk-fta0k-c6f39e61a6.json";
 
-            FirebaseApp.Create(new AppOptions()
-            {
-                Credential = GoogleCredential.FromFile(credentialsPath)
-            });
+                FirebaseApp.Create(new AppOptions()
+                {
+                    Credential = GoogleCredential.FromFile(credentialsPath)
+                });
 
-            isInitialized = true;
+                isInitialized = true;
+            } catch (ArgumentException) {
+                Console.WriteLine("Firebase Initialized");
+            }
+
         }
     }
 }


### PR DESCRIPTION
Still some test does not work with dotnet test because firebase admin is initialized. I add try catch to catch that ArgumentException and do nothing if Firebase admin is already initialized